### PR TITLE
Add dedicated security overview page content

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,30 @@
 import React, { useState } from 'react';
-import { 
-  Calendar, 
-  Shield, 
-  Users, 
-  Settings, 
-  BarChart3, 
-  Search, 
-  Menu, 
+import {
+  Calendar,
+  Shield,
+  Users,
+  Settings,
+  BarChart3,
+  Search,
+  Menu,
   X,
   ChevronRight,
   Check,
   Building,
   UserCheck,
   ShieldCheck,
-  Headphones
+  Headphones,
+  Lock,
+  Bug,
+  Code2,
+  Fingerprint,
+  KeyRound,
+  Siren,
+  Server,
+  MapPin,
+  Mail,
+  Phone,
+  Globe
 } from 'lucide-react';
 
 interface Feature {
@@ -28,6 +39,18 @@ interface PricingTier {
   basePrice: number;
   features: string[];
   popular?: boolean;
+}
+
+interface SecurityHighlight {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}
+
+interface SecurityPolicy {
+  title: string;
+  description: string;
+  details: string;
 }
 
 function App() {
@@ -132,6 +155,80 @@ function App() {
         "24/7 Phone Support"
       ]
     }
+  ];
+
+  const securityHighlights: SecurityHighlight[] = [
+    {
+      icon: <ShieldCheck className="w-10 h-10" />,
+      title: "Regular Security Tests",
+      description:
+        "Internal audits and dependency monitoring keep our platform resilient against new threats with rapid remediation workflows."
+    },
+    {
+      icon: <Bug className="w-10 h-10" />,
+      title: "Daily Malware Scan",
+      description:
+        "Independent Linux Kern scans certify the core application daily and rotate servers to harden long-running attack surfaces."
+    },
+    {
+      icon: <Code2 className="w-10 h-10" />,
+      title: "Secure Development",
+      description:
+        "Mandatory reviews, coding standards, and built-in security consultations ensure every release meets our quality bar."
+    },
+    {
+      icon: <Lock className="w-10 h-10" />,
+      title: "Login Safeguards",
+      description:
+        "Accounts temporarily lock after repeated failed attempts, protecting sensitive legal data from brute-force activity."
+    },
+    {
+      icon: <KeyRound className="w-10 h-10" />,
+      title: "Password Policies",
+      description:
+        "Enforce strong passwords, scheduled resets, and breached password checks directly within Legistant settings."
+    },
+    {
+      icon: <Server className="w-10 h-10" />,
+      title: "Security Blueprint",
+      description:
+        "Our 500-point blueprint guides responses to emerging incidents with constant updates from leading security advisories."
+    }
+  ];
+
+  const securityPolicies: SecurityPolicy[] = [
+    {
+      title: "Role Based Permissions",
+      description: "Granular access controls",
+      details:
+        "Restrict case visibility to authorized lawyers and staff, ensuring confidential client information stays protected."
+    },
+    {
+      title: "Standard Security Practices",
+      description: "Industry-grade protections",
+      details:
+        "TLS encryption, strict transport security, minimal encrypted cookies, and adaptive firewalls safeguard your workspace."
+    },
+    {
+      title: "Login Tracking",
+      description: "Visibility into account activity",
+      details:
+        "Monitor IP addresses and block unfamiliar geographies to identify suspicious access before it becomes an incident."
+    },
+    {
+      title: "Employee Safeguards",
+      description: "Trained and verified team",
+      details:
+        "Office access controls, 2FA enforcement, device policies, background checks, and recurring security training."
+    }
+  ];
+
+  const securityTips: string[] = [
+    "Forbid common passwords and encourage memorable pass phrases",
+    "Require numeric, special, upper, and lowercase characters",
+    "Enforce minimum lengths of at least sixteen characters",
+    "Rotate passwords on a defined schedule with lifetime policies",
+    "Check credentials against breach databases using hashed lookups"
   ];
 
   const renderHome = () => (
@@ -244,11 +341,17 @@ function App() {
             >
               Start Free Trial
             </a>
-            <button 
+            <button
               onClick={() => setCurrentPage('pricing')}
               className="border-2 border-white text-white hover:bg-white hover:text-black font-semibold px-8 py-4 rounded-xl transition-all duration-300"
             >
               View Pricing
+            </button>
+            <button
+              onClick={() => setCurrentPage('security')}
+              className="border-2 border-yellow-400 text-yellow-400 hover:bg-yellow-400 hover:text-black font-semibold px-8 py-4 rounded-xl transition-all duration-300"
+            >
+              Security Overview
             </button>
           </div>
         </div>
@@ -377,6 +480,185 @@ function App() {
     </section>
   );
 
+  const renderSecurity = () => (
+    <div className="bg-gray-50">
+      <section className="relative py-24 text-white">
+        <div
+          className="absolute inset-0"
+          style={{
+            backgroundImage: "url('https://legistant.com/wp-content/uploads/2019/11/img-team-2-1.png')",
+            backgroundSize: 'cover',
+            backgroundPosition: 'center'
+          }}
+        ></div>
+        <div className="absolute inset-0 bg-black/80"></div>
+        <div className="relative container mx-auto px-6">
+          <div className="max-w-3xl">
+            <p className="text-yellow-400 font-semibold uppercase tracking-widest mb-4">Legistant Security</p>
+            <h1 className="text-4xl lg:text-5xl font-bold mb-6">Legistant's Security Promise</h1>
+            <p className="text-lg text-gray-200 leading-relaxed mb-6">
+              Staying ahead of cybersecurity developments is core to Legistant. We continuously review and update our codebase,
+              monitor vulnerabilities, and operate in accordance with GDPR as both a data controller and data processor.
+            </p>
+            <p className="text-lg text-gray-200 leading-relaxed">
+              Our internal teams standardize security protocols—from office access to employee training—to keep your legal data safe.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-20">
+        <div className="container mx-auto px-6">
+          <div className="grid lg:grid-cols-3 gap-8">
+            {securityHighlights.map((highlight, index) => (
+              <div
+                key={index}
+                className="bg-white rounded-2xl p-8 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-2"
+              >
+                <div className="text-yellow-500 mb-6">{highlight.icon}</div>
+                <h3 className="text-2xl font-semibold text-black mb-3">{highlight.title}</h3>
+                <p className="text-gray-600 leading-relaxed">{highlight.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-20 bg-white">
+        <div className="container mx-auto px-6">
+          <div className="flex flex-col lg:flex-row gap-12 items-start">
+            <div className="lg:w-3/5">
+              <h2 className="text-4xl font-bold text-black mb-6">Security Policies and Practices</h2>
+              <p className="text-lg text-gray-600 mb-8">
+                Our blueprint covers more than 500 security threats and keeps us prepared for evolving incidents. We subscribe to
+                leading security bulletins and partner with external auditors to maintain compliance and trust.
+              </p>
+              <div className="grid md:grid-cols-2 gap-6">
+                {securityPolicies.map((policy, index) => (
+                  <div key={index} className="bg-gray-50 border border-gray-200 rounded-2xl p-6">
+                    <h3 className="text-xl font-semibold text-black mb-2">{policy.title}</h3>
+                    <p className="text-sm text-yellow-500 font-medium mb-3">{policy.description}</p>
+                    <p className="text-gray-600 leading-relaxed">{policy.details}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="lg:w-2/5 bg-black text-white rounded-2xl p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <Fingerprint className="w-10 h-10 text-yellow-400" />
+                <div>
+                  <h3 className="text-2xl font-semibold">Login Safeguards</h3>
+                  <p className="text-gray-300 text-sm">Visibility, control, and secure access</p>
+                </div>
+              </div>
+              <ul className="space-y-4 text-gray-200">
+                <li className="flex items-start gap-3">
+                  <ChevronRight className="w-5 h-5 text-yellow-400 mt-1" />
+                  <span>Temporary account locks after repeated failed login attempts stop brute-force attacks.</span>
+                </li>
+                <li className="flex items-start gap-3">
+                  <ChevronRight className="w-5 h-5 text-yellow-400 mt-1" />
+                  <span>IP-based login tracking highlights suspicious access and blocks unfamiliar regions.</span>
+                </li>
+                <li className="flex items-start gap-3">
+                  <ChevronRight className="w-5 h-5 text-yellow-400 mt-1" />
+                  <span>Role-based permissions limit sensitive case information to authorized legal professionals.</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-20">
+        <div className="container mx-auto px-6">
+          <div className="grid lg:grid-cols-2 gap-12 items-start">
+            <div>
+              <h2 className="text-3xl font-bold text-black mb-6">Password Policy Recommendations</h2>
+              <p className="text-gray-600 mb-6">
+                Legistant provides configurable password settings so administrators can tailor controls to their firm. Use these
+                best practices to maximize account resilience.
+              </p>
+              <ul className="space-y-4">
+                {securityTips.map((tip, index) => (
+                  <li key={index} className="flex items-start gap-3">
+                    <Check className="w-5 h-5 text-yellow-500 mt-1" />
+                    <span className="text-gray-700">{tip}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="bg-white rounded-2xl p-8 shadow-lg border border-gray-100">
+              <h3 className="text-2xl font-bold text-black mb-4">Security Tips for Your Team</h3>
+              <div className="space-y-6 text-gray-600">
+                <div>
+                  <h4 className="text-xl font-semibold text-black mb-2">Lock It Up</h4>
+                  <p>Never leave devices unattended and secure external drives that store case information.</p>
+                </div>
+                <div>
+                  <h4 className="text-xl font-semibold text-black mb-2">Practice Safe Clicking</h4>
+                  <p>Inspect unexpected links and attachments. Verify URLs to avoid spoofed domains designed to harvest credentials.</p>
+                </div>
+                <div>
+                  <h4 className="text-xl font-semibold text-black mb-2">Beware of Browsing</h4>
+                  <p>Perform sensitive work only on trusted devices and networks to prevent session hijacking or data theft.</p>
+                </div>
+                <div>
+                  <h4 className="text-xl font-semibold text-black mb-2">Stay Vigilant</h4>
+                  <p>Monitor accounts for unfamiliar activity and report anomalies immediately to your Legistant administrator.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-20 bg-black text-white">
+        <div className="container mx-auto px-6">
+          <div className="grid lg:grid-cols-2 gap-12">
+            <div>
+              <h2 className="text-3xl font-bold mb-4">Our Commitment to You</h2>
+              <p className="text-gray-300 mb-6">
+                We are designed and developed by Sri Lankan IT professionals in partnership with legal experts, and we welcome your questions about Legistant security.
+              </p>
+              <div className="space-y-4 text-gray-300">
+                <p className="flex items-start gap-3">
+                  <MapPin className="w-5 h-5 text-yellow-400 mt-1" />
+                  <span>110 - 1/1, Havelock Road, Colombo 05, Sri Lanka</span>
+                </p>
+                <p className="flex items-start gap-3">
+                  <Mail className="w-5 h-5 text-yellow-400 mt-1" />
+                  <span>info@legistant.com</span>
+                </p>
+                <p className="flex items-start gap-3">
+                  <Phone className="w-5 h-5 text-yellow-400 mt-1" />
+                  <span>+94 77 627 3901 • +94 77 838 5938</span>
+                </p>
+                <p className="flex items-start gap-3">
+                  <Globe className="w-5 h-5 text-yellow-400 mt-1" />
+                  <span>www.legistant.com</span>
+                </p>
+              </div>
+            </div>
+            <div className="bg-white text-black rounded-2xl p-8">
+              <h3 className="text-2xl font-bold mb-4">Need to Report an Issue?</h3>
+              <p className="text-gray-700 mb-6">
+                Contact us anytime to discuss vulnerabilities, compliance requirements, or custom security assessments for your firm.
+              </p>
+              <a
+                href="mailto:info@legistant.com"
+                className="inline-flex items-center gap-2 bg-yellow-400 hover:bg-yellow-300 text-black font-semibold px-6 py-3 rounded-xl transition-all duration-300"
+              >
+                <Siren className="w-5 h-5" />
+                Report a Security Concern
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+
   return (
     <div className="min-h-screen bg-white">
       {/* Navigation */}
@@ -405,13 +687,19 @@ function App() {
               >
                 Features
               </button>
-              <button 
+              <button
                 onClick={() => setCurrentPage('pricing')}
                 className={`hover:text-yellow-400 transition-colors ${currentPage === 'pricing' ? 'text-yellow-400' : ''}`}
               >
                 Pricing
               </button>
-              <a 
+              <button
+                onClick={() => setCurrentPage('security')}
+                className={`hover:text-yellow-400 transition-colors ${currentPage === 'security' ? 'text-yellow-400' : ''}`}
+              >
+                Security
+              </button>
+              <a
                 href="https://app.legistant.com/login"
                 className="bg-yellow-400 hover:bg-yellow-300 text-black px-4 py-2 rounded-lg font-semibold transition-all duration-300"
               >
@@ -446,13 +734,19 @@ function App() {
                 >
                   Features
                 </button>
-                <button 
+                <button
                   onClick={() => { setCurrentPage('pricing'); setMobileMenuOpen(false); }}
                   className={`text-left hover:text-yellow-400 transition-colors ${currentPage === 'pricing' ? 'text-yellow-400' : ''}`}
                 >
                   Pricing
                 </button>
-                <a 
+                <button
+                  onClick={() => { setCurrentPage('security'); setMobileMenuOpen(false); }}
+                  className={`text-left hover:text-yellow-400 transition-colors ${currentPage === 'security' ? 'text-yellow-400' : ''}`}
+                >
+                  Security
+                </button>
+                <a
                   href="https://app.legistant.com/login"
                   className="bg-yellow-400 hover:bg-yellow-300 text-black px-4 py-2 rounded-lg font-semibold transition-all duration-300 text-center"
                 >
@@ -468,6 +762,7 @@ function App() {
       {currentPage === 'home' && renderHome()}
       {currentPage === 'features' && renderFeatures()}
       {currentPage === 'pricing' && renderPricing()}
+      {currentPage === 'security' && renderSecurity()}
 
       {/* Footer */}
       <footer className="bg-black text-white py-12">
@@ -488,6 +783,7 @@ function App() {
               <ul className="space-y-2 text-gray-400">
                 <li><button onClick={() => setCurrentPage('features')} className="hover:text-white transition-colors">Features</button></li>
                 <li><button onClick={() => setCurrentPage('pricing')} className="hover:text-white transition-colors">Pricing</button></li>
+                <li><button onClick={() => setCurrentPage('security')} className="hover:text-white transition-colors">Security</button></li>
                 <li><a href="https://app.legistant.com/login" className="hover:text-white transition-colors">Login</a></li>
               </ul>
             </div>


### PR DESCRIPTION
## Summary
- add a new security overview page with hero, highlights, policies, and tips drawn from historical Legistant content
- wire security navigation into desktop, mobile, and footer menus plus CTA entry points
- expand icon imports and supporting data structures for reusable security sections

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb64e618988331949e5300d2bfcdce